### PR TITLE
[TMP] Memory tests failing with optimizations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,5 @@ rustflags = [
 
 [profile.release]
 lto = true
-opt-level = 0
 codegen-units = 1
 strip = "symbols"

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,15 @@ endif
 
 CFLAGS = -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -ffreestanding -fno-stack-protector -fomit-frame-pointer -falign-jumps -falign-functions -falign-labels -falign-loops -mno-red-zone -Wall -Werror -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-cpp
 
-CARGO_FLAGS = --offline --release
-CARGO_TARGET_DIR = build/kernel/x86_64-unknown-none/release
+CARGO_FLAGS = --offline
+CARGO_TARGET_DIR = build/kernel/x86_64-unknown-none/debug
 
 DEBUG = 0
 
 ifeq ($(DEBUG), 0)
 CFLAGS += -Os -finline-functions
+CARGO_FLAGS += --release
+CARGO_TARGET_DIR = build/kernel/x86_64-unknown-none/release
 else
 CFLAGS += -O0 -g
 endif

--- a/src/memory/paging/tracing/page.rs
+++ b/src/memory/paging/tracing/page.rs
@@ -832,7 +832,15 @@ impl TracingPage {
         if !self.can_push(&md) {
             return Err(TracingPageError::PushPreconditions);
         }
-        Ok(self.push(md))
+        crate::tty::print("\n### try_push()");
+        let exceeding_md = self.push(md);
+        crate::tty::print("\n### try_push() > exceeding_md = ");
+        match exceeding_md.is_some() {
+            true => crate::tty::print("Some"),
+            false => crate::tty::print("None"),
+        }
+        Ok(exceeding_md)
+        // Ok(self.push(md))
     }
 
     /// Inserts the given [`Metadata`] entry at the first position of the array
@@ -853,6 +861,7 @@ impl TracingPage {
     /// Returns [`Some`] containing a [`Metadata`] entry if the array is full and the last
     /// entry needs to be moved to the next [`TracingPage`], or [`None`] otherwise.
     fn push(&mut self, md:Metadata) -> Option<Metadata> {
+        crate::tty::print("\n### push()");
         if self.is_empty() {
             self.append_unchecked(md);
             return None;
@@ -867,6 +876,11 @@ impl TracingPage {
             false => None,
         };
         self.insert_unchecked(0, md);
+        crate::tty::print("\n### push() > exceeding_md = ");
+        match exceeding_md.is_some() {
+            true => crate::tty::print("Some"),
+            false => crate::tty::print("None"),
+        }
         exceeding_md
     }
 


### PR DESCRIPTION
Issue: #6

### Steps to reproduce

1. Compile in `debug` mode: **all tests passing**
  ```
  make VM=bochs TEST=1 DEBUG=1
  ```
2. Compile in `release` mode: **some tests failing**
  ```
  make VM=bochs TEST=1 DEBUG=0
  ```

### Output difference

- Correct output
  ```
  ### try_push()
  ### push()
  ### push() > exceeding_md = None
  ### try_push() > exceeding_md = None
  ```
- Erroneous output
  ```
  ### try_push()
  ### push()
  ### push() > exceeding_md = None
  ### try_push() > exceeding_md = Some
  ```

### Observations

- The returned value is changed, despite no other instruction is (or should, theoretically) executed in between
- Compiling in _release_ mode with `opt-level = 0` results in the same behavior as of compiling in _debug_ mode